### PR TITLE
descriptions: improve composability and use of xacro features

### DIFF
--- a/duaro_description/urdf/duaro.urdf.xacro
+++ b/duaro_description/urdf/duaro.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find duaro_description)/urdf/duaro_macro.xacro"/>
 
   <!-- instantiate duaro -->
-  <xacro:khi_duaro />
+  <xacro:khi_duaro prefix="" />
 
   <!-- Fix duaro to world -->
 

--- a/duaro_description/urdf/duaro.urdf.xacro
+++ b/duaro_description/urdf/duaro.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
-<robot name="duaro" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="khi_duaro" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find duaro_description)/urdf/duaro_macro.xacro"/>
 
   <!-- instantiate duaro -->
-  <xacro:duaro />
+  <xacro:khi_duaro />
 
   <!-- Fix duaro to world -->
 

--- a/duaro_description/urdf/duaro_macro.xacro
+++ b/duaro_description/urdf/duaro_macro.xacro
@@ -29,28 +29,29 @@
     <xacro:property name="U2_length" value="0.124648"/>
 
     <!-- joint limits [rad][m] -->
-    <xacro:property name="J1_LOWER_lower_limit" value="${-pi*170/180}"/>
-    <xacro:property name="J1_LOWER_upper_limit" value="${pi*170/180}"/>
-    <xacro:property name="J2_LOWER_lower_limit" value="${-pi*140/180}"/>
-    <xacro:property name="J2_LOWER_upper_limit" value="${pi*140/180}"/>
+    <xacro:property name="J1_LOWER_lower_limit" value="${radians(-170)}"/>
+    <xacro:property name="J1_LOWER_upper_limit" value="${radians( 170)}"/>
+    <xacro:property name="J2_LOWER_lower_limit" value="${radians(-140)}"/>
+    <xacro:property name="J2_LOWER_upper_limit" value="${radians( 140)}"/>
     <xacro:property name="J3_LOWER_lower_limit" value="0"/>
     <xacro:property name="J3_LOWER_upper_limit" value="0.15"/>
-    <xacro:property name="J4_LOWER_lower_limit" value="${-pi*2}"/>
-    <xacro:property name="J4_LOWER_upper_limit" value="${pi*2}"/>
-    <xacro:property name="J1_UPPER_lower_limit" value="${-pi*140/180}"/>
-    <xacro:property name="J1_UPPER_upper_limit" value="${pi*500/180}"/>
-    <xacro:property name="J2_UPPER_lower_limit" value="${-pi*140/180}"/>
-    <xacro:property name="J2_UPPER_upper_limit" value="${pi*140/180}"/>
+    <xacro:property name="J4_LOWER_lower_limit" value="${radians(-360)}"/>
+    <xacro:property name="J4_LOWER_upper_limit" value="${radians( 360)}"/>
+
+    <xacro:property name="J1_UPPER_lower_limit" value="${radians(-140)}"/>
+    <xacro:property name="J1_UPPER_upper_limit" value="${radians( 500)}"/>
+    <xacro:property name="J2_UPPER_lower_limit" value="${radians(-140)}"/>
+    <xacro:property name="J2_UPPER_upper_limit" value="${radians( 140)}"/>
     <xacro:property name="J3_UPPER_lower_limit" value="0"/>
     <xacro:property name="J3_UPPER_upper_limit" value="0.15"/>
-    <xacro:property name="J4_UPPER_lower_limit" value="${-pi*2}"/>
-    <xacro:property name="J4_UPPER_upper_limit" value="${pi*2}"/>
+    <xacro:property name="J4_UPPER_lower_limit" value="${radians(-360)}"/>
+    <xacro:property name="J4_UPPER_upper_limit" value="${radians( 360)}"/>
 
     <!-- joint velocity limits [rad/s][m/s]-->
-    <xacro:property name="J1_velocity_limit" value="${pi*240/180}"/>
-    <xacro:property name="J2_velocity_limit" value="${pi*315/180}"/>
+    <xacro:property name="J1_velocity_limit" value="${radians(240)}"/>
+    <xacro:property name="J2_velocity_limit" value="${radians(315)}"/>
     <xacro:property name="J3_velocity_limit" value="0.3"/>
-    <xacro:property name="J4_velocity_limit" value="${pi*600/180}"/>
+    <xacro:property name="J4_velocity_limit" value="${radians(600)}"/>
 
     <!-- link rviz color-->
     <material name="Light_blue">

--- a/duaro_description/urdf/duaro_macro.xacro
+++ b/duaro_description/urdf/duaro_macro.xacro
@@ -4,9 +4,6 @@
 
     <xacro:include filename="$(find duaro_description)/urdf/duaro.transmission.xacro" />
 
-    <!-- mathematical value --> 
-    <xacro:property name="pi" value="3.14159265359" />
-
     <!-- DH params -->
     <xacro:property name="dh_j1_j2_transy" value="0.36"/>
     <xacro:property name="dh_j2_j3_transy" value="0.40"/>

--- a/duaro_description/urdf/duaro_macro.xacro
+++ b/duaro_description/urdf/duaro_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="khi_duaro">
+  <xacro:macro name="khi_duaro" params="prefix">
 
     <xacro:include filename="$(find duaro_description)/urdf/duaro.transmission.xacro" />
 
@@ -80,7 +80,7 @@
       </inertial>
     </xacro:macro>
 
-    <link name="base_link">
+    <link name="${prefix}base_link">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A201_Adjuster_pad_Ver2m.stl"/>
@@ -99,9 +99,9 @@
 
 
     <!-- fixed parts xacro-->
-    <xacro:macro name="fixed_parts" params="color name height rot mass">
+    <xacro:macro name="fixed_parts" params="prefix:=^ color name height rot mass">
 
-      <link name="${name}">
+      <link name="${prefix}${name}">
         <visual>
           <geometry>
             <mesh filename="package://duaro_description/meshes/${name}.stl"/>
@@ -118,9 +118,9 @@
         <xacro:default_inertial mass="${mass}"/>
       </link>
 
-      <joint name="${name}_joint" type="fixed">
-        <parent link="base_link"/>
-        <child link="${name}"/>
+      <joint name="${prefix}${name}_joint" type="fixed">
+        <parent link="${prefix}base_link"/>
+        <child link="${prefix}${name}"/>
         <origin xyz="0 0 ${height}" rpy="0 0 0" />
       </joint>
 
@@ -132,7 +132,7 @@
     <xacro:fixed_parts color="Black" name="duaro_logo" height="0" rot="${pi/2}" mass="1"/>
     <xacro:fixed_parts color="Light_blue" name="pedestal_obstacle" height="0" rot="0" mass="2"/>
 
-    <link name="duaro_j0">
+    <link name="${prefix}duaro_j0">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/joint0.stl"/>
@@ -150,14 +150,14 @@
     </link>
 
 
-    <joint name="joint0" type="fixed">
+    <joint name="${prefix}joint0" type="fixed">
       <origin xyz="0 0 0.82"/>
-      <parent link="duaro_body"/>
-      <child link="duaro_j0"/>
+      <parent link="${prefix}duaro_body"/>
+      <child link="${prefix}duaro_j0"/>
     </joint>
 
     <!-- lower arm -->
-    <link name="lower_link_j1">
+    <link name="${prefix}lower_link_j1">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/lower_joint1.stl"/>
@@ -175,17 +175,17 @@
       <xacro:link_inertial Izz="${L1_Izz}" length="${L1_length}" mass="${L1_mass}"/>
     </link>
 
-    <joint name="lower_joint1" type="revolute">
+    <joint name="${prefix}lower_joint1" type="revolute">
         <axis xyz="0 0 1" rpy="0 0 0" />
         <limit effort="100.0" lower="${J1_LOWER_lower_limit}" upper="${J1_LOWER_upper_limit}" velocity="${J1_velocity_limit}"/>
         <origin xyz="0 0 0.2515" rpy="0 0 0"/>
-        <parent link="duaro_j0"/>
-        <child link="lower_link_j1"/>
+        <parent link="${prefix}duaro_j0"/>
+        <child link="${prefix}lower_link_j1"/>
         <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
 
-    <link name="lower_link_j2">
+    <link name="${prefix}lower_link_j2">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202L_J2m.stl"/>
@@ -203,16 +203,16 @@
       <xacro:link_inertial Izz="${L2_Izz}" length="${L2_length}" mass="${L2_mass}"/>
     </link>
 
-    <joint name="lower_joint2" type="revolute">
+    <joint name="${prefix}lower_joint2" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="100.0" lower="${J2_LOWER_lower_limit}" upper="${J2_LOWER_upper_limit}" velocity="${J2_velocity_limit}"/>
       <origin xyz="0 ${dh_j1_j2_transy} 0.0905"/>
-      <parent link="lower_link_j1"/>
-      <child link="lower_link_j2"/>
+      <parent link="${prefix}lower_link_j1"/>
+      <child link="${prefix}lower_link_j2"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="lower_link_j3">
+    <link name="${prefix}lower_link_j3">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202L_J3m.stl"/>
@@ -230,15 +230,15 @@
       <xacro:default_inertial mass="${L3_mass}"/>
     </link>
 
-    <joint name="lower_joint3" type="prismatic">
+    <joint name="${prefix}lower_joint3" type="prismatic">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="100.0" lower="${J3_LOWER_lower_limit}" upper="${J3_LOWER_upper_limit}" velocity="${J3_velocity_limit}"/>
       <origin xyz="0 ${dh_j2_j3_transy} 0.03850"/>
-      <parent link="lower_link_j2"/>
-      <child link="lower_link_j3"/>
+      <parent link="${prefix}lower_link_j2"/>
+      <child link="${prefix}lower_link_j3"/>
     </joint>
 
-    <link name="lower_link_j3_obst">
+    <link name="${prefix}lower_link_j3_obst">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202L_J3_obstaclem.stl"/>
@@ -248,13 +248,13 @@
       </visual>
     </link>
 
-    <joint name="lower_j3_obstaclem_joint" type="fixed">
+    <joint name="${prefix}lower_j3_obstaclem_joint" type="fixed">
       <origin rpy="0 0 0" xyz="0 0 0"/>
-      <parent link="lower_link_j3"/>
-      <child link="lower_link_j3_obst"/>
+      <parent link="${prefix}lower_link_j3"/>
+      <child link="${prefix}lower_link_j3_obst"/>
     </joint>
 
-    <link name="lower_link_j4">
+    <link name="${prefix}lower_link_j4">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202L_J4m.stl"/>
@@ -272,17 +272,17 @@
       <xacro:default_inertial mass="0.5"/>
     </link>
 
-    <joint name="lower_joint4" type="revolute">
+    <joint name="${prefix}lower_joint4" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="100.0" lower="${J4_LOWER_lower_limit}" upper="${J4_LOWER_upper_limit}" velocity="${J4_velocity_limit}"/>
       <origin xyz="0 0 -0.24"/>
-      <parent link="lower_link_j3"/>
-      <child link="lower_link_j4"/>
+      <parent link="${prefix}lower_link_j3"/>
+      <child link="${prefix}lower_link_j4"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
     <!-- upper arm -->
-    <link name="upper_link_j1">
+    <link name="${prefix}upper_link_j1">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A201U_J1_Ver2m.stl"/>
@@ -300,17 +300,17 @@
       <xacro:link_inertial Izz="${U1_Izz}" length="${U1_length}" mass="${U1_mass}"/>
     </link>
 
-    <joint name="upper_joint1" type="revolute">
+    <joint name="${prefix}upper_joint1" type="revolute">
       <origin rpy="0 0 0" xyz="0 0 0.3805"/>
         <axis xyz="0 0 1" rpy="0 0 0" />
         <limit effort="100.0" lower="${J1_UPPER_lower_limit}" upper="${J1_UPPER_upper_limit}" velocity="${J1_velocity_limit}"/>
-        <parent link="duaro_j0"/>
-        <child link="upper_link_j1"/>
+        <parent link="${prefix}duaro_j0"/>
+        <child link="${prefix}upper_link_j1"/>
         <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
 
-    <link name="upper_link_j2">
+    <link name="${prefix}upper_link_j2">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202U_J2m.stl"/>
@@ -328,16 +328,16 @@
       <xacro:link_inertial Izz="${U2_Izz}" length="${U2_length}" mass="${U2_mass}"/>
     </link>
 
-    <joint name="upper_joint2" type="revolute">
+    <joint name="${prefix}upper_joint2" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="100.0" lower="${J2_UPPER_lower_limit}" upper="${J2_UPPER_upper_limit}" velocity="${J2_velocity_limit}"/>
       <origin xyz="0 ${dh_j1_j2_transy} 0"/>
-      <parent link="upper_link_j1"/>
-      <child link="upper_link_j2"/>
+      <parent link="${prefix}upper_link_j1"/>
+      <child link="${prefix}upper_link_j2"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="upper_link_j3">
+    <link name="${prefix}upper_link_j3">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202U_J3m.stl"/>
@@ -355,15 +355,15 @@
       <xacro:default_inertial mass="${U3_mass}"/>
     </link>
 
-    <joint name="upper_joint3" type="prismatic">
+    <joint name="${prefix}upper_joint3" type="prismatic">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="100.0" lower="${J3_UPPER_lower_limit}" upper="${J3_UPPER_upper_limit}" velocity="${J3_velocity_limit}"/>
       <origin xyz="0 ${dh_j2_j3_transy} 0"/>
-      <parent link="upper_link_j2"/>
-      <child link="upper_link_j3"/>
+      <parent link="${prefix}upper_link_j2"/>
+      <child link="${prefix}upper_link_j3"/>
     </joint>
 
-    <link name="upper_link_j3_obst">
+    <link name="${prefix}upper_link_j3_obst">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202U_J3_obstaclem.stl"/>
@@ -373,13 +373,13 @@
       </visual>
     </link>
 
-    <joint name="upper_j3_obstaclem_joint" type="fixed">
+    <joint name="${prefix}upper_j3_obstaclem_joint" type="fixed">
       <origin xyz="0 0 0"/>
-      <parent link="upper_link_j3"/>
-      <child link="upper_link_j3_obst"/>
+      <parent link="${prefix}upper_link_j3"/>
+      <child link="${prefix}upper_link_j3_obst"/>
     </joint>
 
-   <link name="upper_link_j4">
+   <link name="${prefix}upper_link_j4">
       <visual>
         <geometry>
           <mesh filename="package://duaro_description/meshes/WD002N_A202U_J4m.stl"/>
@@ -397,12 +397,12 @@
       <xacro:default_inertial mass="10"/>
     </link>
 
-    <joint name="upper_joint4" type="revolute">
+    <joint name="${prefix}upper_joint4" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="100.0" lower="${J4_UPPER_lower_limit}" upper="${J4_UPPER_upper_limit}" velocity="${J3_velocity_limit}"/>
       <origin xyz="0 0 -0.24"/>
-      <parent link="upper_link_j3"/>
-      <child link="upper_link_j4"/>
+      <parent link="${prefix}upper_link_j3"/>
+      <child link="${prefix}upper_link_j4"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
@@ -412,23 +412,23 @@
       <material>Gazebo/${colors}</material>
     </gazebo>
     </xacro:macro>
-    <xacro:gazebo_color parts="duaro_body" colors="White"/>
-    <xacro:gazebo_color parts="pedestal_obstacle" colors="Light_blue"/>
-    <xacro:gazebo_color parts="duaro_logo" colors="Black"/>
-    <xacro:gazebo_color parts="base_link" colors="White"/>
-    <xacro:gazebo_color parts="duaro_j0" colors="White"/>
-    <xacro:gazebo_color parts="duaro_j0_cover" colors="Light_blue"/>
-    <xacro:gazebo_color parts="lower_link_j1" colors="White"/>
-    <xacro:gazebo_color parts="lower_link_j2" colors="White"/>
-    <xacro:gazebo_color parts="lower_link_j3" colors="White"/>
-    <xacro:gazebo_color parts="lower_link_j4" colors="White"/>
-    <xacro:gazebo_color parts="lower_link_j3_obst" colors="Black"/>
-    <xacro:gazebo_color parts="upper_link_j1" colors="White"/>
-    <xacro:gazebo_color parts="upper_link_j2" colors="White"/>
-    <xacro:gazebo_color parts="upper_link_j3" colors="White"/>
-    <xacro:gazebo_color parts="upper_link_j4" colors="White"/>
-    <xacro:gazebo_color parts="upper_link_j3_obst" colors="Black"/>
-    <xacro:gazebo_color parts="duaro_body" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}duaro_body" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}pedestal_obstacle" colors="Light_blue"/>
+    <xacro:gazebo_color parts="${prefix}duaro_logo" colors="Black"/>
+    <xacro:gazebo_color parts="${prefix}base_link" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}duaro_j0" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}duaro_j0_cover" colors="Light_blue"/>
+    <xacro:gazebo_color parts="${prefix}lower_link_j1" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}lower_link_j2" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}lower_link_j3" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}lower_link_j4" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}lower_link_j3_obst" colors="Black"/>
+    <xacro:gazebo_color parts="${prefix}upper_link_j1" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}upper_link_j2" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}upper_link_j3" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}upper_link_j4" colors="White"/>
+    <xacro:gazebo_color parts="${prefix}upper_link_j3_obst" colors="Black"/>
+    <xacro:gazebo_color parts="${prefix}duaro_body" colors="White"/>
 
     <!-- duaro end -->
     <gazebo>

--- a/duaro_description/urdf/duaro_macro.xacro
+++ b/duaro_description/urdf/duaro_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="duaro">
+  <xacro:macro name="khi_duaro">
 
     <xacro:include filename="$(find duaro_description)/urdf/duaro.transmission.xacro" />
 

--- a/rs_description/urdf/rs007l.urdf.xacro
+++ b/rs_description/urdf/rs007l.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
-<robot name="rs007l" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="khi_rs007l" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find rs_description)/urdf/rs007l_macro.xacro"/>
 
   <!-- instantiate rs007l -->
-  <xacro:rs007l />
+  <xacro:khi_rs007l />
 
   <!-- Fix rs007l to world -->
 

--- a/rs_description/urdf/rs007l.urdf.xacro
+++ b/rs_description/urdf/rs007l.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find rs_description)/urdf/rs007l_macro.xacro"/>
 
   <!-- instantiate rs007l -->
-  <xacro:khi_rs007l />
+  <xacro:khi_rs007l prefix="" />
 
   <!-- Fix rs007l to world -->
 

--- a/rs_description/urdf/rs007l_macro.xacro
+++ b/rs_description/urdf/rs007l_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="rs007l">
+  <xacro:macro name="khi_rs007l">
 
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />

--- a/rs_description/urdf/rs007l_macro.xacro
+++ b/rs_description/urdf/rs007l_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="khi_rs007l">
+  <xacro:macro name="khi_rs007l" params="prefix">
 
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />
@@ -70,7 +70,7 @@
     <!-- rs007l start -->
 
     <!-- Link 0 -->
-    <link name="base_link">
+    <link name="${prefix}base_link">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007L_J0.stl"/>
@@ -89,17 +89,17 @@
     </link>
 
     <!-- Link 1 -->
-    <joint name="joint1" type="revolute">
+    <joint name="${prefix}joint1" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j1_lower_limit}" upper="${j1_upper_limit}" velocity="${j1_velocity_limit}"/>
       <origin xyz="0 0 ${j0_length}" rpy="0 0 0" />
-      <parent link="base_link"/>
-      <child link="link1"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link1"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
 
-    <link name="link1">
+    <link name="${prefix}link1">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007L_J1.stl"/>
@@ -118,16 +118,16 @@
     </link>
 
     <!-- Link 2 -->
-    <joint name="joint2" type="revolute">
+    <joint name="${prefix}joint2" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j2_lower_limit}" upper="${j2_upper_limit}" velocity="${j2_velocity_limit}"/>
       <origin xyz="0 0 ${j1_length}" rpy="0 ${dh_j1_j2_roty} 0" />
-      <parent link="link1"/>
-      <child link="link2"/>
+      <parent link="${prefix}link1"/>
+      <child link="${prefix}link2"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link2">
+    <link name="${prefix}link2">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007L_J2.stl"/>
@@ -146,16 +146,16 @@
     </link>
 
     <!-- Link 3 -->
-    <joint name="joint3" type="revolute">
+    <joint name="${prefix}joint3" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j3_lower_limit}" upper="${j3_upper_limit}" velocity="${j3_velocity_limit}"/>
       <origin xyz="${j2_length} 0 0" rpy="0 0 0" />
-      <parent link="link2"/>
-      <child link="link3"/>
+      <parent link="${prefix}link2"/>
+      <child link="${prefix}link3"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link3">
+    <link name="${prefix}link3">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007L_J3.stl"/>
@@ -174,16 +174,16 @@
     </link>
 
     <!-- Link 4 -->
-    <joint name="joint4" type="revolute">
+    <joint name="${prefix}joint4" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j4_lower_limit}" upper="${j4_upper_limit}" velocity="${j4_velocity_limit}"/>
       <origin xyz="${j3_length} 0 0" rpy="0 ${dh_j3_j4_roty} 0" />
-      <parent link="link3"/>
-      <child link="link4"/>
+      <parent link="${prefix}link3"/>
+      <child link="${prefix}link4"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link4">
+    <link name="${prefix}link4">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007L_J4.stl"/>
@@ -202,16 +202,16 @@
     </link>
 
     <!-- Link 5 -->
-    <joint name="joint5" type="revolute">
+    <joint name="${prefix}joint5" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j5_lower_limit}" upper="${j5_upper_limit}" velocity="${j5_velocity_limit}"/>
       <origin xyz="0 0 ${j4_length}" rpy="0 ${dh_j4_j5_roty} 0" />
-      <parent link="link4"/>
-      <child link="link5"/>
+      <parent link="${prefix}link4"/>
+      <child link="${prefix}link5"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link5">
+    <link name="${prefix}link5">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007L_J5.stl"/>
@@ -230,16 +230,16 @@
     </link>
 
     <!-- Link 6 -->
-    <joint name="joint6" type="revolute">
+    <joint name="${prefix}joint6" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j6_lower_limit}" upper="${j6_upper_limit}" velocity="${j6_velocity_limit}"/>
       <origin xyz="${j5_length} 0 0" rpy="0 ${dh_j5_j6_roty} 0" />
-      <parent link="link5"/>
-      <child link="link6"/>
+      <parent link="${prefix}link5"/>
+      <child link="${prefix}link6"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link6">
+    <link name="${prefix}link6">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007L_J6.stl"/>

--- a/rs_description/urdf/rs007l_macro.xacro
+++ b/rs_description/urdf/rs007l_macro.xacro
@@ -5,9 +5,6 @@
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />
 
-    <!-- mathematics value--> 
-    <xacro:property name="pi" value="3.14159265359" />
-
     <!-- link rviz colors -->
     <material name="White">
       <color rgba="1 1 1 1"/>

--- a/rs_description/urdf/rs007l_macro.xacro
+++ b/rs_description/urdf/rs007l_macro.xacro
@@ -15,10 +15,10 @@
     </material>
 
     <!-- DH parameters -->
-    <xacro:property name="dh_j1_j2_roty" value="-${pi/2}"/>
-    <xacro:property name="dh_j3_j4_roty" value="${pi/2}"/>
-    <xacro:property name="dh_j4_j5_roty" value="-${pi/2}"/>
-    <xacro:property name="dh_j5_j6_roty" value="${pi/2}"/>
+    <xacro:property name="dh_j1_j2_roty" value="${radians(-90)}"/>
+    <xacro:property name="dh_j3_j4_roty" value="${radians( 90)}"/>
+    <xacro:property name="dh_j4_j5_roty" value="${radians(-90)}"/>
+    <xacro:property name="dh_j5_j6_roty" value="${radians( 90)}"/>
 
     <!-- link mass [kg] -->
     <xacro:property name="j0_mass" value="11"/>
@@ -38,26 +38,26 @@
     <xacro:property name="j5_length" value="0.078"/>
     
     <!-- joint limits [rad] -->
-    <xacro:property name="j1_lower_limit" value="${-pi}"/>
-    <xacro:property name="j1_upper_limit" value="${pi}"/>
-    <xacro:property name="j2_lower_limit" value="${-pi*135/180}"/>
-    <xacro:property name="j2_upper_limit" value="${pi*135/180}"/>
-    <xacro:property name="j3_lower_limit" value="${-pi*157/180}"/>
-    <xacro:property name="j3_upper_limit" value="${pi*157/180}"/>
-    <xacro:property name="j4_lower_limit" value="${-pi*200/180}"/>
-    <xacro:property name="j4_upper_limit" value="${pi*200/180}"/>
-    <xacro:property name="j5_lower_limit" value="${-pi*125/180}"/>
-    <xacro:property name="j5_upper_limit" value="${pi*125/180}"/>
-    <xacro:property name="j6_lower_limit" value="${-2*pi}"/>
-    <xacro:property name="j6_upper_limit" value="${2*pi}"/>
+    <xacro:property name="j1_lower_limit" value="${radians(-180)}"/>
+    <xacro:property name="j1_upper_limit" value="${radians( 180)}"/>
+    <xacro:property name="j2_lower_limit" value="${radians(-135)}"/>
+    <xacro:property name="j2_upper_limit" value="${radians( 135)}"/>
+    <xacro:property name="j3_lower_limit" value="${radians(-157)}"/>
+    <xacro:property name="j3_upper_limit" value="${radians( 157)}"/>
+    <xacro:property name="j4_lower_limit" value="${radians(-200)}"/>
+    <xacro:property name="j4_upper_limit" value="${radians( 200)}"/>
+    <xacro:property name="j5_lower_limit" value="${radians(-125)}"/>
+    <xacro:property name="j5_upper_limit" value="${radians( 125)}"/>
+    <xacro:property name="j6_lower_limit" value="${radians(-360)}"/>
+    <xacro:property name="j6_upper_limit" value="${radians( 360)}"/>
 
     <!-- joint verocity limits [rad/s] -->
-    <xacro:property name="j1_velocity_limit" value="${pi*370/180}"/>
-    <xacro:property name="j2_velocity_limit" value="${pi*310/180}"/>
-    <xacro:property name="j3_velocity_limit" value="${pi*410/180}"/>
-    <xacro:property name="j4_velocity_limit" value="${pi*550/180}"/>
-    <xacro:property name="j5_velocity_limit" value="${pi*550/180}"/>
-    <xacro:property name="j6_velocity_limit" value="${pi*1000/180}"/>
+    <xacro:property name="j1_velocity_limit" value="${radians( 370)}"/>
+    <xacro:property name="j2_velocity_limit" value="${radians( 310)}"/>
+    <xacro:property name="j3_velocity_limit" value="${radians( 410)}"/>
+    <xacro:property name="j4_velocity_limit" value="${radians( 550)}"/>
+    <xacro:property name="j5_velocity_limit" value="${radians( 550)}"/>
+    <xacro:property name="j6_velocity_limit" value="${radians(1000)}"/>
 
     <!-- link inertial(TODO : set correct link inertial )-->
     <xacro:macro name="default_inertial" params="mass">

--- a/rs_description/urdf/rs007n.urdf.xacro
+++ b/rs_description/urdf/rs007n.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
-<robot name="rs007n" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="khi_rs007n" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find rs_description)/urdf/rs007n_macro.xacro"/>
 
   <!-- instantiate rs007n -->
-  <xacro:rs007n />
+  <xacro:khi_rs007n />
 
   <!-- Fix rs007n to world -->
 

--- a/rs_description/urdf/rs007n.urdf.xacro
+++ b/rs_description/urdf/rs007n.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find rs_description)/urdf/rs007n_macro.xacro"/>
 
   <!-- instantiate rs007n -->
-  <xacro:khi_rs007n />
+  <xacro:khi_rs007n prefix="" />
 
   <!-- Fix rs007n to world -->
 

--- a/rs_description/urdf/rs007n_macro.xacro
+++ b/rs_description/urdf/rs007n_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="rs007n">
+  <xacro:macro name="khi_rs007n">
 
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />

--- a/rs_description/urdf/rs007n_macro.xacro
+++ b/rs_description/urdf/rs007n_macro.xacro
@@ -5,9 +5,6 @@
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />
 
-    <!-- mathematics value--> 
-    <xacro:property name="pi" value="3.1415" />
-
     <!-- link rviz colors -->
     <material name="White">
       <color rgba="1 1 1 1"/>

--- a/rs_description/urdf/rs007n_macro.xacro
+++ b/rs_description/urdf/rs007n_macro.xacro
@@ -15,10 +15,10 @@
     </material>
 
     <!-- DH parameters -->
-    <xacro:property name="dh_j1_j2_roty" value="-${pi/2}"/>
-    <xacro:property name="dh_j3_j4_roty" value="${pi/2}"/>
-    <xacro:property name="dh_j4_j5_roty" value="-${pi/2}"/>
-    <xacro:property name="dh_j5_j6_roty" value="${pi/2}"/>
+    <xacro:property name="dh_j1_j2_roty" value="${radians(-90)}"/>
+    <xacro:property name="dh_j3_j4_roty" value="${radians( 90)}"/>
+    <xacro:property name="dh_j4_j5_roty" value="${radians(-90)}"/>
+    <xacro:property name="dh_j5_j6_roty" value="${radians( 90)}"/>
 
     <!-- link mass [kg] -->
     <xacro:property name="j0_mass" value="11"/>
@@ -38,26 +38,26 @@
     <xacro:property name="j5_length" value="0.078"/>
     
     <!-- joint limits [rad] -->
-    <xacro:property name="j1_lower_limit" value="${-pi}"/>
-    <xacro:property name="j1_upper_limit" value="${pi}"/>
-    <xacro:property name="j2_lower_limit" value="${-pi*135/180}"/>
-    <xacro:property name="j2_upper_limit" value="${pi*135/180}"/>
-    <xacro:property name="j3_lower_limit" value="${-pi*155/180}"/>
-    <xacro:property name="j3_upper_limit" value="${pi*155/180}"/>
-    <xacro:property name="j4_lower_limit" value="${-pi*200/180}"/>
-    <xacro:property name="j4_upper_limit" value="${pi*200/180}"/>
-    <xacro:property name="j5_lower_limit" value="${-pi*125/180}"/>
-    <xacro:property name="j5_upper_limit" value="${pi*125/180}"/>
-    <xacro:property name="j6_lower_limit" value="${-2*pi}"/>
-    <xacro:property name="j6_upper_limit" value="${2*pi}"/>
+    <xacro:property name="j1_lower_limit" value="${radians(-180)}"/>
+    <xacro:property name="j1_upper_limit" value="${radians( 180)}"/>
+    <xacro:property name="j2_lower_limit" value="${radians(-135)}"/>
+    <xacro:property name="j2_upper_limit" value="${radians( 135)}"/>
+    <xacro:property name="j3_lower_limit" value="${radians(-155)}"/>
+    <xacro:property name="j3_upper_limit" value="${radians( 155)}"/>
+    <xacro:property name="j4_lower_limit" value="${radians(-200)}"/>
+    <xacro:property name="j4_upper_limit" value="${radians( 200)}"/>
+    <xacro:property name="j5_lower_limit" value="${radians(-125)}"/>
+    <xacro:property name="j5_upper_limit" value="${radians( 125)}"/>
+    <xacro:property name="j6_lower_limit" value="${radians(-360)}"/>
+    <xacro:property name="j6_upper_limit" value="${radians( 360)}"/>
 
     <!-- joint verocity limits [rad/s] -->
-    <xacro:property name="j1_velocity_limit" value="${pi*470/180}"/>
-    <xacro:property name="j2_velocity_limit" value="${pi*380/180}"/>
-    <xacro:property name="j3_velocity_limit" value="${pi*520/180}"/>
-    <xacro:property name="j4_velocity_limit" value="${pi*550/180}"/>
-    <xacro:property name="j5_velocity_limit" value="${pi*550/180}"/>
-    <xacro:property name="j6_velocity_limit" value="${pi*1000/180}"/>
+    <xacro:property name="j1_velocity_limit" value="${radians( 470)}"/>
+    <xacro:property name="j2_velocity_limit" value="${radians( 380)}"/>
+    <xacro:property name="j3_velocity_limit" value="${radians( 520)}"/>
+    <xacro:property name="j4_velocity_limit" value="${radians( 550)}"/>
+    <xacro:property name="j5_velocity_limit" value="${radians( 550)}"/>
+    <xacro:property name="j6_velocity_limit" value="${radians(1000)}"/>
 
     <!-- link inertial(TODO : set correct link inertial )-->
     <xacro:macro name="default_inertial" params="mass">

--- a/rs_description/urdf/rs007n_macro.xacro
+++ b/rs_description/urdf/rs007n_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="khi_rs007n">
+  <xacro:macro name="khi_rs007n" params="prefix">
 
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />
@@ -70,7 +70,7 @@
     <!-- rs007n start -->
 
     <!-- Link 0 -->
-    <link name="base_link">
+    <link name="${prefix}base_link">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007N_J0.stl"/>
@@ -89,17 +89,17 @@
     </link>
 
     <!-- Link 1 -->
-    <joint name="joint1" type="revolute">
+    <joint name="${prefix}joint1" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j1_lower_limit}" upper="${j1_upper_limit}" velocity="${j1_velocity_limit}"/>
       <origin xyz="0 0 ${j0_length}" rpy="0 0 0" />
-      <parent link="base_link"/>
-      <child link="link1"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link1"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
 
-    <link name="link1">
+    <link name="${prefix}link1">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007N_J1.stl"/>
@@ -118,16 +118,16 @@
     </link>
 
     <!-- Link 2 -->
-    <joint name="joint2" type="revolute">
+    <joint name="${prefix}joint2" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j2_lower_limit}" upper="${j2_upper_limit}" velocity="${j2_velocity_limit}"/>
       <origin xyz="0 0 ${j1_length}" rpy="0 ${dh_j1_j2_roty} 0" />
-      <parent link="link1"/>
-      <child link="link2"/>
+      <parent link="${prefix}link1"/>
+      <child link="${prefix}link2"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link2">
+    <link name="${prefix}link2">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007N_J2.stl"/>
@@ -146,16 +146,16 @@
     </link>
 
     <!-- Link 3 -->
-    <joint name="joint3" type="revolute">
+    <joint name="${prefix}joint3" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j3_lower_limit}" upper="${j3_upper_limit}" velocity="${j3_velocity_limit}"/>
       <origin xyz="${j2_length} 0 0" rpy="0 0 0" />
-      <parent link="link2"/>
-      <child link="link3"/>
+      <parent link="${prefix}link2"/>
+      <child link="${prefix}link3"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link3">
+    <link name="${prefix}link3">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007N_J3.stl"/>
@@ -174,16 +174,16 @@
     </link>
 
     <!-- Link 4 -->
-    <joint name="joint4" type="revolute">
+    <joint name="${prefix}joint4" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j4_lower_limit}" upper="${j4_upper_limit}" velocity="${j4_velocity_limit}"/>
       <origin xyz="${j3_length} 0 0" rpy="0 ${dh_j3_j4_roty} 0" />
-      <parent link="link3"/>
-      <child link="link4"/>
+      <parent link="${prefix}link3"/>
+      <child link="${prefix}link4"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link4">
+    <link name="${prefix}link4">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007N_J4.stl"/>
@@ -202,16 +202,16 @@
     </link>
 
     <!-- Link 5 -->
-    <joint name="joint5" type="revolute">
+    <joint name="${prefix}joint5" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j5_lower_limit}" upper="${j5_upper_limit}" velocity="${j5_velocity_limit}"/>
       <origin xyz="0 0 ${j4_length}" rpy="0 ${dh_j4_j5_roty} 0" />
-      <parent link="link4"/>
-      <child link="link5"/>
+      <parent link="${prefix}link4"/>
+      <child link="${prefix}link5"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link5">
+    <link name="${prefix}link5">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007N_J5.stl"/>
@@ -230,16 +230,16 @@
     </link>
 
     <!-- Link 6 -->
-    <joint name="joint6" type="revolute">
+    <joint name="${prefix}joint6" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j6_lower_limit}" upper="${j6_upper_limit}" velocity="${j6_velocity_limit}"/>
       <origin xyz="${j5_length} 0 0" rpy="0 ${dh_j5_j6_roty} 0" />
-      <parent link="link5"/>
-      <child link="link6"/>
+      <parent link="${prefix}link5"/>
+      <child link="${prefix}link6"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link6">
+    <link name="${prefix}link6">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS007N_J6.stl"/>

--- a/rs_description/urdf/rs080n.urdf.xacro
+++ b/rs_description/urdf/rs080n.urdf.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
-<robot name="rs080n" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="khi_rs080n" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find rs_description)/urdf/rs080n_macro.xacro"/>
 
   <!-- instantiate rs080n -->
-  <xacro:rs080n />
+  <xacro:khi_rs080n />
 
   <!-- Fix rs080n to world -->
 

--- a/rs_description/urdf/rs080n.urdf.xacro
+++ b/rs_description/urdf/rs080n.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find rs_description)/urdf/rs080n_macro.xacro"/>
 
   <!-- instantiate rs080n -->
-  <xacro:khi_rs080n />
+  <xacro:khi_rs080n prefix="" />
 
   <!-- Fix rs080n to world -->
 

--- a/rs_description/urdf/rs080n_macro.xacro
+++ b/rs_description/urdf/rs080n_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="rs080n">
+  <xacro:macro name="khi_rs080n">
 
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />

--- a/rs_description/urdf/rs080n_macro.xacro
+++ b/rs_description/urdf/rs080n_macro.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="khi_rs080n">
+  <xacro:macro name="khi_rs080n" params="prefix">
 
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />
@@ -70,7 +70,7 @@
     <!-- rs080n start -->
 
     <!-- Link 0 -->
-    <link name="base_link">
+    <link name="${prefix}base_link">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS080N_J0.stl"/>
@@ -89,17 +89,17 @@
     </link>
 
     <!-- Link 1 -->
-    <joint name="joint1" type="revolute">
+    <joint name="${prefix}joint1" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j1_lower_limit}" upper="${j1_upper_limit}" velocity="${j1_velocity_limit}"/>
       <origin xyz="0 0 ${j0_length}" rpy="0 0 0" />
-      <parent link="base_link"/>
-      <child link="link1"/>
+      <parent link="${prefix}base_link"/>
+      <child link="${prefix}link1"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
 
-    <link name="link1">
+    <link name="${prefix}link1">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS080N_J1.stl"/>
@@ -118,16 +118,16 @@
     </link>
 
     <!-- Link 2 -->
-    <joint name="joint2" type="revolute">
+    <joint name="${prefix}joint2" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j2_lower_limit}" upper="${j2_upper_limit}" velocity="${j2_velocity_limit}"/>
       <origin xyz="0 ${j1_length} 0" rpy="0 ${dh_j1_j2_roty} 0" />
-      <parent link="link1"/>
-      <child link="link2"/>
+      <parent link="${prefix}link1"/>
+      <child link="${prefix}link2"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link2">
+    <link name="${prefix}link2">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS080N_J2.stl"/>
@@ -146,16 +146,16 @@
     </link>
 
     <!-- Link 3 -->
-    <joint name="joint3" type="revolute">
+    <joint name="${prefix}joint3" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j3_lower_limit}" upper="${j3_upper_limit}" velocity="${j3_velocity_limit}"/>
       <origin xyz="${j2_length} 0 0" rpy="0 0 0" />
-      <parent link="link2"/>
-      <child link="link3"/>
+      <parent link="${prefix}link2"/>
+      <child link="${prefix}link3"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link3">
+    <link name="${prefix}link3">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS080N_J3.stl"/>
@@ -174,16 +174,16 @@
     </link>
 
     <!-- Link 4 -->
-    <joint name="joint4" type="revolute">
+    <joint name="${prefix}joint4" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j4_lower_limit}" upper="${j4_upper_limit}" velocity="${j4_velocity_limit}"/>
       <origin xyz="${j3_length} 0 0" rpy="0 ${dh_j3_j4_roty} 0" />
-      <parent link="link3"/>
-      <child link="link4"/>
+      <parent link="${prefix}link3"/>
+      <child link="${prefix}link4"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link4">
+    <link name="${prefix}link4">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS080N_J4.stl"/>
@@ -202,16 +202,16 @@
     </link>
 
     <!-- Link 5 -->
-    <joint name="joint5" type="revolute">
+    <joint name="${prefix}joint5" type="revolute">
       <axis xyz="0 0 -1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j5_lower_limit}" upper="${j5_upper_limit}" velocity="${j5_velocity_limit}"/>
       <origin xyz="0 0 ${j4_length}" rpy="0 ${dh_j4_j5_roty} 0" />
-      <parent link="link4"/>
-      <child link="link5"/>
+      <parent link="${prefix}link4"/>
+      <child link="${prefix}link5"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link5">
+    <link name="${prefix}link5">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS080N_J5.stl"/>
@@ -230,16 +230,16 @@
     </link>
 
     <!-- Link 6 -->
-    <joint name="joint6" type="revolute">
+    <joint name="${prefix}joint6" type="revolute">
       <axis xyz="0 0 1" rpy="0 0 0" />
       <limit effort="1000.0" lower="${j6_lower_limit}" upper="${j6_upper_limit}" velocity="${j6_velocity_limit}"/>
       <origin xyz="${j5_length} 0 0" rpy="0 ${dh_j5_j6_roty} 0" />
-      <parent link="link5"/>
-      <child link="link6"/>
+      <parent link="${prefix}link5"/>
+      <child link="${prefix}link6"/>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
 
-    <link name="link6">
+    <link name="${prefix}link6">
       <visual>
         <geometry>
           <mesh filename="package://rs_description/meshes/RS080N_J6.stl"/>

--- a/rs_description/urdf/rs080n_macro.xacro
+++ b/rs_description/urdf/rs080n_macro.xacro
@@ -5,9 +5,6 @@
     <xacro:include filename="$(find rs_description)/urdf/rs.transmission.xacro" />
     <xacro:include filename="$(find rs_description)/urdf/common.gazebo.xacro" />
 
-    <!-- mathematics value--> 
-    <xacro:property name="pi" value="3.14159265359" />
-
     <!-- link rviz colors -->
     <material name="White">
       <color rgba="1 1 1 1"/>

--- a/rs_description/urdf/rs080n_macro.xacro
+++ b/rs_description/urdf/rs080n_macro.xacro
@@ -15,10 +15,10 @@
     </material>
 
     <!-- DH parameters -->
-    <xacro:property name="dh_j1_j2_roty" value="-${pi/2}"/>
-    <xacro:property name="dh_j3_j4_roty" value="${pi/2}"/>
-    <xacro:property name="dh_j4_j5_roty" value="-${pi/2}"/>
-    <xacro:property name="dh_j5_j6_roty" value="${pi/2}"/>
+    <xacro:property name="dh_j1_j2_roty" value="${radians(-90)}"/>
+    <xacro:property name="dh_j3_j4_roty" value="${radians( 90)}"/>
+    <xacro:property name="dh_j4_j5_roty" value="${radians(-90)}"/>
+    <xacro:property name="dh_j5_j6_roty" value="${radians( 90)}"/>
 
     <!-- link mass [kg] -->
     <xacro:property name="j0_mass" value="200"/> <!-- TO-DO -->
@@ -38,26 +38,26 @@
     <xacro:property name="j5_length" value="0.165"/>
     
     <!-- joint limits [rad] -->
-    <xacro:property name="j1_lower_limit" value="${-pi}"/>
-    <xacro:property name="j1_upper_limit" value="${pi}"/>
-    <xacro:property name="j2_lower_limit" value="${-pi*105/180}"/>
-    <xacro:property name="j2_upper_limit" value="${pi*140/180}"/>
-    <xacro:property name="j3_lower_limit" value="${-pi*155/180}"/>
-    <xacro:property name="j3_upper_limit" value="${pi*135/180}"/>
-    <xacro:property name="j4_lower_limit" value="${-pi*360/180}"/>
-    <xacro:property name="j4_upper_limit" value="${pi*360/180}"/>
-    <xacro:property name="j5_lower_limit" value="${-pi*145/180}"/>
-    <xacro:property name="j5_upper_limit" value="${pi*145/180}"/>
-    <xacro:property name="j6_lower_limit" value="${-pi*360/180}"/>
-    <xacro:property name="j6_upper_limit" value="${pi*360/180}"/>
+    <xacro:property name="j1_lower_limit" value="${radians(-180)}"/>
+    <xacro:property name="j1_upper_limit" value="${radians( 180)}"/>
+    <xacro:property name="j2_lower_limit" value="${radians(-105)}"/>
+    <xacro:property name="j2_upper_limit" value="${radians( 140)}"/>
+    <xacro:property name="j3_lower_limit" value="${radians(-155)}"/>
+    <xacro:property name="j3_upper_limit" value="${radians( 135)}"/>
+    <xacro:property name="j4_lower_limit" value="${radians(-360)}"/>
+    <xacro:property name="j4_upper_limit" value="${radians( 360)}"/>
+    <xacro:property name="j5_lower_limit" value="${radians(-145)}"/>
+    <xacro:property name="j5_upper_limit" value="${radians( 145)}"/>
+    <xacro:property name="j6_lower_limit" value="${radians(-360)}"/>
+    <xacro:property name="j6_upper_limit" value="${radians( 360)}"/>
 
     <!-- joint velocity limits [rad/s] -->
-    <xacro:property name="j1_velocity_limit" value="${pi*180/180}"/>
-    <xacro:property name="j2_velocity_limit" value="${pi*180/180}"/>
-    <xacro:property name="j3_velocity_limit" value="${pi*160/180}"/>
-    <xacro:property name="j4_velocity_limit" value="${pi*185/180}"/>
-    <xacro:property name="j5_velocity_limit" value="${pi*165/180}"/>
-    <xacro:property name="j6_velocity_limit" value="${pi*280/180}"/>
+    <xacro:property name="j1_velocity_limit" value="${radians(180)}"/>
+    <xacro:property name="j2_velocity_limit" value="${radians(180)}"/>
+    <xacro:property name="j3_velocity_limit" value="${radians(160)}"/>
+    <xacro:property name="j4_velocity_limit" value="${radians(185)}"/>
+    <xacro:property name="j5_velocity_limit" value="${radians(165)}"/>
+    <xacro:property name="j6_velocity_limit" value="${radians(280)}"/>
 
     <!-- link inertial(TODO : set correct link inertial )-->
     <xacro:macro name="default_inertial" params="mass">


### PR DESCRIPTION
As per subject.

This PR mostly improves ease-of-use when trying to integrate KHI robot macros into workcells. It does this in two ways:

 1. prefixing all macro names with `khi_`: this avoids name clashes with other macros
 1. adding a `prefix` argument to the macros: this allows xacro to automatically update `joint` and `link` names whenever a KHI macro is called. This can be used when adding two instances of the same robot model to a scene (giving each a different prefix, such as `left_` and `right_`) or when adding a KHI robot model to a larger scene, where names like `base_link` and `joint3` are already used by other models

The other commits in this PR introduce use of some convenience functions that `xacro` offers (`radians(..)` and use of standard constant `pi`).
