### PR TITLE
robot_control: fix msg deps of main.

### DIFF
--- a/khi_robot_control/CMakeLists.txt
+++ b/khi_robot_control/CMakeLists.txt
@@ -56,6 +56,9 @@ add_library(khi_robot_client src/khi_robot_client.cpp src/khi_robot_krnx_driver.
 ## Declare a C++ executable for ROS_CONTROL
 add_executable(main src/main.cpp src/khi_robot_hardware_interface.cpp)
 
+## Specify that we depend on msgs package
+add_dependencies(khi_robot_client ${catkin_EXPORTED_TARGETS})
+
 ## Specify libraries to link a library or executable target against
 target_link_libraries(khi_robot_client ${catkin_LIBRARIES} ${krnx_LIBRARIES})
 target_link_libraries(main ${catkin_LIBRARIES} khi_robot_client)


### PR DESCRIPTION
As per subject.

This was correct in #5 (after a comment by @d-nakamichi), but the merge of #6 introduced this mistake again.
