### PR TITLE
Add test_depend

### DIFF
--- a/khi_robot_control/package.xml
+++ b/khi_robot_control/package.xml
@@ -34,4 +34,6 @@
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>transmission_interface</run_depend>
   <run_depend>khi_robot_msgs</run_depend>
+
+  <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
`khi_robot_control` was failed to build in version release `1.1.0`

http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__khi_robot_control__ubuntu_xenial_amd64__binary/13/console

It was because `khi_robot_control` has dependency on `rostest`.
```
19:43:32 CMake Error at CMakeLists.txt:67 (find_package):
19:43:32   By not providing "Findrostest.cmake" in CMAKE_MODULE_PATH this project has
19:43:32   asked CMake to find a package configuration file provided by "rostest", but
19:43:32   CMake did not find one.
19:43:32 
19:43:32   Could not find a package configuration file provided by "rostest" with any
19:43:32   of the following names:
19:43:32 
19:43:32     rostestConfig.cmake
19:43:32     rostest-config.cmake
19:43:32 
19:43:32   Add the installation prefix of "rostest" to CMAKE_PREFIX_PATH or set
19:43:32   "rostest_DIR" to a directory containing one of the above files.  If
19:43:32   "rostest" provides a separate development package or SDK, be sure it has
19:43:32   been installed.
19:43:32 
19:43:32 
19:43:32 -- Configuring incomplete, errors occurred!
19:43:32 See also "/tmp/binarydeb/ros-kinetic-khi-robot-control-1.1.0/obj-x86_64-linux-gnu/CMakeFiles/CMakeOutput.log".
19:43:32 See also "/tmp/binarydeb/ros-kinetic-khi-robot-control-1.1.0/obj-x86_64-linux-gnu/CMakeFiles/CMakeError.log".
19:43:32 	cd /tmp/binarydeb/ros-kinetic-khi-robot-control-1.1.0
19:43:32 	cd obj-x86_64-linux-gnu
19:43:32 	"tail -v -n +0 CMakeCache.txt"
19:43:32 ==> CMakeCache.txt <==
```

So I add `<test_depend>rostest</test_depend>` in `khi_robot_control`.