### PR TITLE
Limit AS control axes to ROS driver's control axes

### DIFF
--- a/khi_robot_control/src/khi_robot_krnx_driver.cpp
+++ b/khi_robot_control/src/khi_robot_krnx_driver.cpp
@@ -324,6 +324,7 @@ bool KhiRobotKrnxDriver::activate( const int cont_no, JointData *joint )
             {
                 return_code = krnx_ExecMon( cont_no, "SW ZDBLREFFLT_MODSTABLE=OFF", msg_buf, sizeof(msg_buf), &error_code );
             }
+            krnx_SetRtcCompMask( cont_no, ano, pow( 2, p_rb_tbl[cont_no]->arm_tbl[ano].jt_num ) - 1 );
         }
         /* Motor Power ON */
         return_code = krnx_ExecMon( cont_no, "ZPOW ON", msg_buf, sizeof(msg_buf), &error_code );


### PR DESCRIPTION
It limits AS(KRNX) control axes to ROS driver's control axes.
This enables ROS driver to control a real robot which has external axes.