### PR TITLE
add KHI CAD Data Disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,5 @@ Origin of ROS coordinate is World origin.
 
 ### About CAD data
 
-Please read [KHI CAD Data Disclaimer](https://robotics.kawasaki.com/en1/products/CAD-disclaimer/?language_id=1) before using the CAD data of URDF. 
-
-The STL files in `***_ description` are created based on CAD Data of the above website. Therefore, STL files are also included in this CAD Data Disclaimer.
+`***_ description` are using STL files based on CAD Data of the KHI website.  
+Therefore [KHI CAD Data Disclaimer](https://robotics.kawasaki.com/en1/products/CAD-disclaimer/?language_id=1) is also applied to these files.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ Origin of ROS coordinate is World origin.
 ### About CAD data
 
 Please read [KHI CAD Data Disclaimer](https://robotics.kawasaki.com/en1/products/CAD-disclaimer/?language_id=1) before using the CAD data of URDF. 
+
+The STL files in `***_ description` are created based on CAD Data of the above website. Therefore, STL files are also included in this CAD Data Disclaimer.

--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ Origin of KHI coordinate is Robot Link1 origin.
 
 Origin of ROS coordinate is World origin.
 ```
+
+### About CAD data
+
+Please read [KHI CAD Data Disclaimer](https://robotics.kawasaki.com/en1/products/CAD-disclaimer/?language_id=1) before using the CAD data of URDF. 

--- a/khi_duaro_description/package.xml
+++ b/khi_duaro_description/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="matsui_hiro@khi.co.jp">matsui_hiro</maintainer>
 
   <license>BSD</license>
+  <license>KHI CAD license (mesh data, see readme)</license>
 
   <url type="website">http://ros.org/wiki/khi_robot</url>
   <url type="repository">https://github.com/Kawasaki-Robotics/khi_robot</url>

--- a/khi_rs_description/package.xml
+++ b/khi_rs_description/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="matsui_hiro@khi.co.jp">matsui_hiro</maintainer>
 
   <license>BSD</license>
+  <license>KHI CAD license (mesh data, see readme)</license>
 
   <url type="website">http://ros.org/wiki/khi_robot</url>
   <url type="repository">https://github.com/Kawasaki-Robotics/khi_robot</url>


### PR DESCRIPTION
LIcense for `** _ description` is BSD.
But, there is a disclaimer of KHI CAD Data.
Therefore, URDF STL files need to be compliant.
I added it to the README.