### PR TITLE
Apply AS switch setting for all robots

### DIFF
--- a/khi_robot_control/include/khi_robot_krnx_driver.h
+++ b/khi_robot_control/include/khi_robot_krnx_driver.h
@@ -94,6 +94,7 @@ private:
     char msg_buf[KRNX_MSGSIZE];
     bool do_restart[KRNX_MAX_CONTROLLER];
     bool do_quit[KRNX_MAX_CONTROLLER];
+    int sw_dblrefflt[KRNX_MAX_CONTROLLER];
 
     /* RTC */
     float rtc_comp[KRNX_MAX_CONTROLLER][KRNX_MAX_ROBOT][KRNX_MAXAXES];

--- a/khi_robot_control/src/khi_robot_krnx_driver.cpp
+++ b/khi_robot_control/src/khi_robot_krnx_driver.cpp
@@ -74,6 +74,7 @@ KhiRobotKrnxDriver::KhiRobotKrnxDriver() : KhiRobotDriver()
         rtc_seq_no[cno]= 0;
         do_restart[cno] = false;
         do_quit[cno] = false;
+        sw_dblrefflt[cno] = 0;
     }
 }
 
@@ -319,7 +320,12 @@ bool KhiRobotKrnxDriver::activate( const int cont_no, JointData *joint )
             rtc_info.interpolation = 1;
             return_code = krnx_SetRtcInfo( cont_no, &rtc_info );
             retKrnxRes( cont_no, "krnx_SetRtcInfo", return_code );
-            return_code = krnx_ExecMon( cont_no, "SW ZDBLREFFLT_MODSTABLE=OFF", msg_buf, sizeof(msg_buf), &error_code );
+            return_code = krnx_ExecMon( cont_no, "TYPE SWITCH(ZDBLREFFLT_MODSTABLE)", msg_buf, sizeof(msg_buf), &error_code );
+            sw_dblrefflt[cont_no] = atoi(msg_buf);
+            if ( sw_dblrefflt[cont_no] == -1 )
+            {
+                return_code = krnx_ExecMon( cont_no, "SW ZDBLREFFLT_MODSTABLE=OFF", msg_buf, sizeof(msg_buf), &error_code );
+            }
             krnx_SetRtcCompMask( cont_no, ano, pow( 2, p_rb_tbl[cont_no]->arm_tbl[ano].jt_num ) - 1 );
         }
         /* Motor Power ON */
@@ -408,6 +414,8 @@ bool KhiRobotKrnxDriver::activate( const int cont_no, JointData *joint )
 
 bool KhiRobotKrnxDriver::deactivate( const int cont_no )
 {
+    char msg[1024] = { 0 };
+
     if ( !contLimitCheck( cont_no, KRNX_MAX_CONTROLLER ) ) { return false; }
 
     if ( in_simulation )
@@ -430,6 +438,12 @@ bool KhiRobotKrnxDriver::deactivate( const int cont_no )
         return_code = krnx_ExecMon( cont_no, "ZPOW OFF", msg_buf, sizeof(msg_buf), &error_code );
         /* Error Reset */
         return_code = krnx_Ereset( cont_no, ano, &error_code );
+        /* Switch Reversion */
+        if ( sw_dblrefflt[cont_no] == -1 )
+        {
+            snprintf( msg, sizeof(msg), "SW ZDBLREFFLT_MODSTABLE=ON" );
+            return_code = krnx_ExecMon( cont_no, msg, msg_buf, sizeof(msg_buf), &error_code );
+        }
     }
 
     setState( cont_no, CONNECTED );

--- a/khi_robot_control/src/khi_robot_krnx_driver.cpp
+++ b/khi_robot_control/src/khi_robot_krnx_driver.cpp
@@ -319,11 +319,7 @@ bool KhiRobotKrnxDriver::activate( const int cont_no, JointData *joint )
             rtc_info.interpolation = 1;
             return_code = krnx_SetRtcInfo( cont_no, &rtc_info );
             retKrnxRes( cont_no, "krnx_SetRtcInfo", return_code );
-            /* duAro Setting */
-            if ( robot_info[cont_no].robot_name == KHI_ROBOT_WD002N )
-            {
-                return_code = krnx_ExecMon( cont_no, "SW ZDBLREFFLT_MODSTABLE=OFF", msg_buf, sizeof(msg_buf), &error_code );
-            }
+            return_code = krnx_ExecMon( cont_no, "SW ZDBLREFFLT_MODSTABLE=OFF", msg_buf, sizeof(msg_buf), &error_code );
             krnx_SetRtcCompMask( cont_no, ano, pow( 2, p_rb_tbl[cont_no]->arm_tbl[ano].jt_num ) - 1 );
         }
         /* Motor Power ON */


### PR DESCRIPTION
To process ROS command smoothly in AS system, it changes AS switch setting for all robots.