### PR TITLE
Bugfix about getting signal status

### DIFF
--- a/khi_robot_control/src/khi_robot_krnx_driver.cpp
+++ b/khi_robot_control/src/khi_robot_krnx_driver.cpp
@@ -1022,19 +1022,19 @@ bool KhiRobotKrnxDriver::commandHandler( khi_robot_msgs::KhiRobotCmd::Request &r
                     if ( arg >= 1 && arg <= KHI_MAX_SIG_SIZE )
                     {
                         /* DO */
-                        onoff = io.io_do[arg/8] & ( 1 << (arg-1)%8 );
+                        onoff = io.io_do[(arg-1)/8] & ( 1 << (arg-1)%8 );
                     }
                     else if ( arg >= 1000 && arg <= 1000 + KHI_MAX_SIG_SIZE )
                     {
                         /* DI */
                         arg -= 1000;
-                        onoff = io.io_di[arg/8] & ( 1 << (arg-1)%8 );
+                        onoff = io.io_di[(arg-1)/8] & ( 1 << (arg-1)%8 );
                     }
                     else if ( arg >= 2001 && arg <= 2000 + KHI_MAX_SIG_SIZE )
                     {
                         /* INTERNAL */
                         arg -= 2000;
-                        onoff = io.internal[arg/8] & ( 1 << (arg-1)%8 );
+                        onoff = io.internal[(arg-1)/8] & ( 1 << (arg-1)%8 );
                     }
                     else
                     {


### PR DESCRIPTION
`get_signal` of `khi_robot_command_service` has a problem.
It cannot get a signal status whose number is multiple of 8.

### Get Signal Status of [NUM]

```text
string type-> "driver"
string cmd -> "get_signal [NUM]"
---
int32 driver_ret -> driver's return code. Refer KRNX_E_*** in krnx.h
int32 as_ret -> AS return code. Refer AS manual.
string cmd_ret -> "-1"(ON) or "0"(OFF)
```

[NUM] range (depended on AS system setting)

```text
Output: 1~512
Input: 1001~1512
Internal: 2001~2512
```