### PR TITLE
Travis test bugfix

### DIFF
--- a/khi_robot_control/src/khi_robot_krnx_driver.cpp
+++ b/khi_robot_control/src/khi_robot_krnx_driver.cpp
@@ -546,12 +546,18 @@ bool KhiRobotKrnxDriver::loadDriverParam( const int cont_no )
 bool KhiRobotKrnxDriver::readData( const int cont_no, JointData *joint )
 {
     static int sim_cnt = 0;
+    static JointData prev_data = *joint;
 
     if ( !contLimitCheck( cont_no, KRNX_MAX_CONTROLLER ) ) { return false; }
 
     if ( in_simulation )
     {
         memcpy( &joint->pos[0], &joint->cmd[0], sizeof(joint->cmd) );
+        for ( int jt = 0; jt < KHI_MAX_JOINT; jt++ )
+        {
+            joint->vel[jt] = joint->pos[jt] - prev_data.pos[jt];
+        }
+        prev_data = *joint;
         if ( ( sim_cnt - 1 ) % KRNX_PRINT_TH == 0 )
         {
             jointPrint( std::string("read"), *joint );

--- a/khi_robot_test/CMakeLists.txt
+++ b/khi_robot_test/CMakeLists.txt
@@ -8,9 +8,7 @@ project(khi_robot_test)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
   rospy
-  std_msgs
 )
 
 ###################################
@@ -23,10 +21,8 @@ find_package(catkin REQUIRED COMPONENTS
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES khi_robot_test
-#  CATKIN_DEPENDS roscpp rospy std_msgs
-#  DEPENDS system_lib
+  CATKIN_DEPENDS
+    rospy
 )
 
 ###########

--- a/khi_robot_test/package.xml
+++ b/khi_robot_test/package.xml
@@ -13,15 +13,10 @@
   <url type="repository">https://github.com/Kawasaki-Robotics/khi_robot</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>khi_robot_msgs</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>khi_robot_bringup</test_depend>


### PR DESCRIPTION
Now travis `i386` test is failing due to reading velocity in `khi_robot_control` simulation.
This PR modifies that and the test.