### PR TITLE
python 3.4 -> default in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@
 sudo: true
 dist: trusty
 language: python
-python:
-  - "3.4"
 env:
   global:
     - JOB_PATH=/tmp/devel_job


### PR DESCRIPTION
Now python 3.4 cannot be used in travis because of dependency of PyYAML.
This PR changes python's version from 3.4 to default (currently 3.6)