### PR TITLE
mod go_initial.sh for Gazebo simulator with ROS Melodic.

### DIFF
--- a/khi_duaro_gazebo/script/go_initial.sh
+++ b/khi_duaro_gazebo/script/go_initial.sh
@@ -6,7 +6,7 @@ sleep 2
 rosservice call /gazebo/unpause_physics
 sleep 1
 #Stop the controllers
-rosservice call /controller_manager/switch_controller [] ["duaro_lower_arm_controller","duaro_upper_arm_controller","joint_state_controller"] 2
+rosservice call /controller_manager/switch_controller "{ start_controllers: [], stop_controllers: [ 'duaro_lower_arm_controller', 'duaro_upper_arm_controller', 'joint_state_controller' ], strictness: 2 }"
 
 rosservice call /gazebo/pause_physics
 rosservice call /gazebo/set_model_configuration '{ model_name: "robot", urdf_param_name: "robot_description", 
@@ -15,6 +15,6 @@ rosservice call /gazebo/set_model_configuration '{ model_name: "robot", urdf_par
 sleep 1
 
 #Start the controllers
-rosservice call /controller_manager/switch_controller ["duaro_lower_arm_controller","duaro_upper_arm_controller","joint_state_controller"] [] 2 &
+rosservice call /controller_manager/switch_controller "{ start_controllers:  [ 'duaro_lower_arm_controller', 'duaro_upper_arm_controller', 'joint_state_controller' ], stop_controllers: [], strictness: 2 }" &
 sleep 1
 rosservice call /gazebo/unpause_physics


### PR DESCRIPTION
I got a problem that duaro arms do not move to the initial postures at starts in Gazebo simulation with ROS Melodic as shown below.

![Screenshot from 2022-04-11 16-25-00](https://user-images.githubusercontent.com/3119480/162686164-8477cd12-f157-465e-b3dd-e8bd359efb0b.png)

And in a terminal that launched Gazebo, there were some errors in go_initial.sh process. 

``` bash
robotuser@robotuser-PC:~/catkin_ws$ roslaunch khi_duaro_gazebo duaro_world.launch
... logging to /home/robotuser/.ros/log/7065704a-b968-11ec-b40e-50eb713af63d/roslaunch-robotuser-PC-5345.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

xacro: in-order processing became default in ROS Melodic. You can drop the option.
started roslaunch server http://robotuser-PC:41533/

SUMMARY
========

PARAMETERS
 * /duaro_lower_arm_controller/constraints/goal_time: 2.0
 * /duaro_lower_arm_controller/constraints/lower_joint1/goal: 0.2
 * /duaro_lower_arm_controller/constraints/lower_joint1/trajectory: 0
 * /duaro_lower_arm_controller/constraints/lower_joint2/goal: 0.2
 * /duaro_lower_arm_controller/constraints/lower_joint2/trajectory: 0
 * /duaro_lower_arm_controller/constraints/lower_joint3/goal: 0.2
 * /duaro_lower_arm_controller/constraints/lower_joint3/trajectory: 0
 * /duaro_lower_arm_controller/constraints/lower_joint4/goal: 0.2
 * /duaro_lower_arm_controller/constraints/lower_joint4/trajectory: 0
 * /duaro_lower_arm_controller/constraints/stopped_velocity_tolerance: 0.1
 * /duaro_lower_arm_controller/joints: ['lower_joint1', ...
 * /duaro_lower_arm_controller/type: position_controll...
 * /duaro_lower_joint_group_controller/joints: ['lower_joint1', ...
 * /duaro_lower_joint_group_controller/type: position_controll...
 * /duaro_upper_arm_controller/action_monitor_rate: 20
 * /duaro_upper_arm_controller/constraints/goal_time: 2.0
 * /duaro_upper_arm_controller/constraints/stopped_velocity_tolerance: 0.1
 * /duaro_upper_arm_controller/constraints/upper_joint1/goal: 0.2
 * /duaro_upper_arm_controller/constraints/upper_joint1/trajectory: 0
 * /duaro_upper_arm_controller/constraints/upper_joint2/goal: 0.2
 * /duaro_upper_arm_controller/constraints/upper_joint2/trajectory: 0
 * /duaro_upper_arm_controller/constraints/upper_joint3/goal: 0.2
 * /duaro_upper_arm_controller/constraints/upper_joint3/trajectory: 0
 * /duaro_upper_arm_controller/constraints/upper_joint4/goal: 0.2
 * /duaro_upper_arm_controller/constraints/upper_joint4/trajectory: 0
 * /duaro_upper_arm_controller/joints: ['upper_joint1', ...
 * /duaro_upper_arm_controller/state_publish_rate: 50
 * /duaro_upper_arm_controller/type: position_controll...
 * /duaro_upper_joint_group_controller/joints: ['upper_joint1', ...
 * /duaro_upper_joint_group_controller/type: position_controll...
 * /gazebo/enable_ros_network: True
 * /joint_state_controller/publish_rate: 50
 * /joint_state_controller/type: joint_state_contr...
 * /robot_description: <?xml version="1....
 * /robot_state_publisher/publish_frequency: 50.0
 * /robot_state_publisher/tf_prefix: 
 * /rosdistro: melodic
 * /rosversion: 1.14.13
 * /use_sim_time: True

NODES
  /
    controller_spawner (controller_manager/spawner)
    fake_joint_calibration (rostopic/rostopic)
    gazebo (gazebo_ros/gzserver)
    gazebo_gui (gazebo_ros/gzclient)
    go_initial (khi_duaro_gazebo/go_initial.sh)
    joint_group_controller_manager (controller_manager/controller_manager)
    robot_state_publisher (robot_state_publisher/robot_state_publisher)
    spawn_gazebo_model (gazebo_ros/spawn_model)

auto-starting new master
process[master]: started with pid [5358]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 7065704a-b968-11ec-b40e-50eb713af63d
process[rosout-1]: started with pid [5369]
started core service [/rosout]
process[gazebo-2]: started with pid [5376]
process[gazebo_gui-3]: started with pid [5381]
process[spawn_gazebo_model-4]: started with pid [5386]
process[robot_state_publisher-5]: started with pid [5387]
process[fake_joint_calibration-6]: started with pid [5388]
process[controller_spawner-7]: started with pid [5389]
process[joint_group_controller_manager-8]: started with pid [5394]
process[go_initial-9]: started with pid [5396]
[ INFO] [1649661877.063592888]: Finished loading Gazebo ROS API Plugin.
[ INFO] [1649661877.065475594]: waitForService: Service [/gazebo/set_physics_properties] has not been advertised, waiting...
[ INFO] [1649661877.069778635]: Finished loading Gazebo ROS API Plugin.
[ INFO] [1649661877.070966694]: waitForService: Service [/gazebo_gui/set_physics_properties] has not been advertised, waiting...
[WARN] [1649661877.076654, 0.000000]: DEPRECATION warning: --shutdown-timeout has no effect.
[INFO] [1649661877.077689, 0.000000]: Controller Spawner: Waiting for service controller_manager/load_controller
[INFO] [1649661877.418917, 0.000000]: Loading model XML from ros parameter robot_description
[INFO] [1649661877.435007, 0.000000]: Waiting for service /gazebo/spawn_urdf_model
[INFO] [1649661877.437430, 0.000000]: Calling service /gazebo/spawn_urdf_model
[ INFO] [1649661877.438563253]: waitForService: Service [/gazebo/set_physics_properties] is now available.
[INFO] [1649661877.739051, 0.150000]: Spawn status: SpawnModel: Successfully spawned entity
[ INFO] [1649661877.747202270, 0.150000000]: Physics dynamic reconfigure ready.
[ INFO] [1649661877.886587671, 0.150000000]: Loading gazebo_ros_control plugin
[ INFO] [1649661877.886706507, 0.150000000]: Starting gazebo_ros_control plugin in namespace: /
[ INFO] [1649661877.887452736, 0.150000000]: gazebo_ros_control plugin is waiting for model URDF in parameter [robot_description] on the ROS param server.
[ERROR] [1649661877.999046468, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/lower_joint1
[ERROR] [1649661877.999759298, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/lower_joint2
[ERROR] [1649661878.000362763, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/lower_joint3
[ERROR] [1649661878.000976609, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/lower_joint4
[ERROR] [1649661878.001597717, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/upper_joint1
[ERROR] [1649661878.002042439, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/upper_joint2
[ERROR] [1649661878.002505578, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/upper_joint3
[ERROR] [1649661878.002903208, 0.150000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/upper_joint4
[ INFO] [1649661878.005675229, 0.150000000]: Loaded gazebo_ros_control.
[spawn_gazebo_model-4] process has finished cleanly
log file: /home/robotuser/.ros/log/7065704a-b968-11ec-b40e-50eb713af63d/spawn_gazebo_model-4*.log
Loaded 'duaro_lower_joint_group_controller'
Loaded 'duaro_upper_joint_group_controller'
[INFO] [1649661878.284367, 0.430000]: Controller Spawner: Waiting for service controller_manager/switch_controller
[INFO] [1649661878.287732, 0.434000]: Controller Spawner: Waiting for service controller_manager/unload_controller
[INFO] [1649661878.292300, 0.438000]: Loading controller: joint_state_controller
[INFO] [1649661878.301733, 0.448000]: Loading controller: duaro_lower_arm_controller
[Err] [REST.cc:205] Error in REST request

libcurl: (51) SSL: no alternative certificate subject name matches target host name 'api.ignitionfuel.org'
[INFO] [1649661878.341623, 0.488000]: Loading controller: duaro_upper_arm_controller
[INFO] [1649661878.365556, 0.512000]: Controller Spawner: Loaded controllers: joint_state_controller, duaro_lower_arm_controller, duaro_upper_arm_controller
[INFO] [1649661878.368557, 0.515000]: Started controllers: joint_state_controller, duaro_lower_arm_controller, duaro_upper_arm_controller
[joint_group_controller_manager-8] process has finished cleanly
log file: /home/robotuser/.ros/log/7065704a-b968-11ec-b40e-50eb713af63d/joint_group_controller_manager-8*.log
ERROR: Incompatible arguments to call service:
Not enough arguments:
 * Given: [[], ['duaro_lower_arm_controller', 'duaro_upper_arm_controller', 'joint_state_controller'], 2]
 * Expected: ['start_controllers', 'stop_controllers', 'strictness', 'start_asap', 'timeout']
Provided arguments are:
 * [] (type list)
 * ['duaro_lower_arm_controller', 'duaro_upper_arm_controller', 'joint_state_controller'] (type list)
 * 2 (type int)

Service arguments are: [start_controllers stop_controllers strictness start_asap timeout]
ERROR: Incompatible arguments to call service:
Not enough arguments:
 * Given: [['duaro_lower_arm_controller', 'duaro_upper_arm_controller', 'joint_state_controller'], [], 2]
 * Expected: ['start_controllers', 'stop_controllers', 'strictness', 'start_asap', 'timeout']
Provided arguments are:
 * ['duaro_lower_arm_controller', 'duaro_upper_arm_controller', 'joint_state_controller'] (type list)
 * [] (type list)
 * 2 (type int)

Service arguments are: [start_controllers stop_controllers strictness start_asap timeout]
[go_initial-9] process has finished cleanly
log file: /home/robotuser/.ros/log/7065704a-b968-11ec-b40e-50eb713af63d/go_initial-9*.log
^C[controller_spawner-7] killing on exit
[fake_joint_calibration-6] killing on exit
[INFO] [1649661911.445098, 28.455000]: Shutting down spawner. Stopping and unloading controllers...
[robot_state_publisher-5] killing on exit
[gazebo_gui-3] killing on exit
[INFO] [1649661911.448007, 28.457000]: Stopping all controllers...
[gazebo-2] killing on exit
[controller_spawner-7] escalating to SIGTERM
[WARN] [1649661926.475797, 28.461000]: Controller Spawner error while taking down controllers: transport error completing service call: unable to receive data from sender, check sender's logs for details
[gazebo-2] escalating to SIGTERM
[gazebo_gui-3] escalating to SIGTERM
[rosout-1] killing on exit
[master] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
done
robotuser@robotuser-PC:~/catkin_ws$ 
```

Following what were suggested in the errors, I modified the style of arguments for controller_manager rosservicecall and confirmed that the arms moved to the initial posutures.
