### PR TITLE
Create the ControllerManager after robot was openned

### DIFF
--- a/khi_robot_control/src/main.cpp
+++ b/khi_robot_control/src/main.cpp
@@ -326,7 +326,6 @@ void *controlLoop( void* )
     struct timespec tick;
     ros::Duration durp( g_options.period_ / 1e+9 );
     khi_robot_control::KhiRobotHardwareInterface robot;
-    controller_manager::ControllerManager cm(&robot);
     double period_diff = 0;
     if ( !robot.open( g_options.robot_, g_options.ip_, g_options.period_, g_options.simulation_ ) )
     {
@@ -337,6 +336,9 @@ void *controlLoop( void* )
         ros::shutdown();
         return NULL;
     }
+
+    controller_manager::ControllerManager cm(&robot);
+
     if ( !activate( robot, &tick ) )
     {
         publisher.stop();


### PR DESCRIPTION
This should fix #69

As mentioned in #69, creating the controller manager before opening the robot can lead to failures at runtime because
the ControllerManager provides services that require the robot to be already opened. If a 3rd party calls one of those
services before the robot is opened, that operation will fail.

By moving the creation of the ControllerManager after we try to open the robot, we ensure that no race condition will occur and that the robot will always be openned when the provided services are called.
