### PR TITLE
Fix controller yml

### DIFF
--- a/khi_robot_bringup/config/duaro_controllers.yaml
+++ b/khi_robot_bringup/config/duaro_controllers.yaml
@@ -22,24 +22,18 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      joint1:
+      lower_joint1:
         trajectory: 0 
-        goal: 0.0       
-      joint2:
+        goal: 0.2       
+      lower_joint2:
         trajectory: 0 
-        goal: 0.0       
-      joint3:
+        goal: 0.2       
+      lower_joint3:
         trajectory: 0 
-        goal: 0.0       
-      joint4:
+        goal: 0.2       
+      lower_joint4:
         trajectory: 0 
-        goal: 0.0             
-      joint5:
-        trajectory: 0 
-        goal: 0.0             
-      joint6:
-        trajectory: 0 
-        goal: 0.0       
+        goal: 0.2       
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_robot_bringup/config/duaro_controllers.yaml
+++ b/khi_robot_bringup/config/duaro_controllers.yaml
@@ -22,18 +22,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2       
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0       
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_robot_bringup/config/rs007l_controllers.yaml
+++ b/khi_robot_bringup/config/rs007l_controllers.yaml
@@ -22,18 +22,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2             
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0             
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_robot_bringup/config/rs007n_controllers.yaml
+++ b/khi_robot_bringup/config/rs007n_controllers.yaml
@@ -22,18 +22,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2             
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0           
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_robot_bringup/config/rs013n_controllers.yaml
+++ b/khi_robot_bringup/config/rs013n_controllers.yaml
@@ -22,18 +22,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2             
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0          
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_robot_bringup/config/rs080n_controllers.yaml
+++ b/khi_robot_bringup/config/rs080n_controllers.yaml
@@ -23,18 +23,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2             
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0              
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_rs_gazebo/config/rs007l_gazebo_control.yaml
+++ b/khi_rs_gazebo/config/rs007l_gazebo_control.yaml
@@ -16,18 +16,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2       
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0      
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_rs_gazebo/config/rs007n_gazebo_control.yaml
+++ b/khi_rs_gazebo/config/rs007n_gazebo_control.yaml
@@ -16,18 +16,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2       
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0      
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_rs_gazebo/config/rs013n_gazebo_control.yaml
+++ b/khi_rs_gazebo/config/rs013n_gazebo_control.yaml
@@ -16,18 +16,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2       
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0      
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_rs_gazebo/config/rs025n_gazebo_control.yaml
+++ b/khi_rs_gazebo/config/rs025n_gazebo_control.yaml
@@ -16,18 +16,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2       
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0       
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20

--- a/khi_rs_gazebo/config/rs080n_gazebo_control.yaml
+++ b/khi_rs_gazebo/config/rs080n_gazebo_control.yaml
@@ -16,18 +16,24 @@
     constraints:
       goal_time: 2.0                   # Defaults to zero
       stopped_velocity_tolerance: 0.1 # Defaults to 0.01
-      lower_joint1:
+      joint1:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint2:
+        goal: 0.0       
+      joint2:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint3:
+        goal: 0.0       
+      joint3:
         trajectory: 0 
-        goal: 0.2       
-      lower_joint4:
+        goal: 0.0       
+      joint4:
         trajectory: 0 
-        goal: 0.2       
+        goal: 0.0             
+      joint5:
+        trajectory: 0 
+        goal: 0.0             
+      joint6:
+        trajectory: 0 
+        goal: 0.0      
 
     state_publish_rate:  50 # Defaults to 50
     action_monitor_rate: 20 # Defaults to 20


### PR DESCRIPTION
In `khi_robot_bringup/config/rs007l_controllers.yaml`

```
    constraints:
      goal_time: 2.0                   # Defaults to zero
      stopped_velocity_tolerance: 0.1 # Defaults to 0.01
      lower_joint1:
        trajectory: 0 
        goal: 0.2       
      lower_joint2:
        trajectory: 0 
        goal: 0.2       
      lower_joint3:
        trajectory: 0 
        goal: 0.2       
      lower_joint4:
        trajectory: 0 
        goal: 0.2     
```        

Correct joint names are `joint1 ~ 6` 
but settings are `lower_joint1 ~ 4`.


Similar descriptions are found in 
`khi_robot_bringup/config/rs007n_controllers.yaml`
`khi_robot_bringup/config/rs007l_controllers.yaml`
`khi_robot_bringup/config/rs013n_controllers.yaml`
`khi_robot_bringup/config/rs080n_controllers.yaml`
`khi_rs_gazebo/config/rs007n_gazebo_control.yaml` 
`khi_rs_gazebo/config/rs007l_gazebo_control.yaml `
`khi_rs_gazebo/config/rs013n_gazebo_control.yaml `
`khi_rs_gazebo/config/rs025n_gazebo_control.yaml `
`khi_rs_gazebo/config/rs080n_gazebo_control.yaml `

This PR changes ..
1. rename `lower_joint1~4 `-> `joint1~6`.
2. change the `trajectory` and `goal`  value to default: 0.0.

The reason to set default values is to not change robot move from previous versions. 
